### PR TITLE
fix #45 and fix #46 by adding pause option and improve cancel handling

### DIFF
--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: '7.5.0'
+clickable_minimum_required: '8.0.0'
 builder: pure-qml-cmake
 framework: ubuntu-sdk-20.04
 

--- a/qml/ActivityDialog.qml
+++ b/qml/ActivityDialog.qml
@@ -35,6 +35,15 @@ Dialog {
    Row {
       spacing: units.gu(1)
       PopUpButton {
+         id: cancel_button
+         texth: i18n.tr("Cancel")
+         height: units.gu(8)
+         width: parent.width /2 -units.gu(0.5)
+         onClicked: {
+           PopupUtils.close(activity_dialogue)
+        }
+      }
+      PopUpButton {
          id: save_button
          texth: i18n.tr("Save")
          height: units.gu(8)
@@ -42,17 +51,6 @@ Dialog {
          color: LomiriColors.green
          enabled: sportsComponent.selected != -1
          // on clicked event is handled in Tracker.qml
-      }
-
-      PopUpButton {
-         id: cancel_button
-         texth: i18n.tr("Cancel")
-         height: units.gu(8)
-         width: parent.width /2 -units.gu(0.5)
-         color: LomiriColors.red
-         onClicked: {
-           PopupUtils.close(activity_dialogue)
-        }
       }
    }
 }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -34,6 +34,7 @@ MainView {
    property var polyline;
    property string day;
    property bool am_running;
+   property bool is_paused;
    property string runits;
    property string timestring : "00:00"
    property string smashkey;

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -1,10 +1,10 @@
 import QtQuick 2.4
-import QtPositioning 5.9
+import QtPositioning 5.12
 import Lomiri.Components 1.3
 import QtQuick.Layouts 1.1
 import io.thp.pyotherside 1.5
 import QtSystemInfo 5.0
-import QtLocation 5.9
+import QtLocation 5.12
 import Lomiri.Components.Popups 1.3
 import Qt.labs.settings 1.0
 import Lomiri.Content 1.3

--- a/qml/Map.qml
+++ b/qml/Map.qml
@@ -1,10 +1,10 @@
 import QtQuick 2.4
-import QtPositioning 5.9
+import QtPositioning 5.12
 import Lomiri.Components 1.3
 import QtQuick.Layouts 1.1
 import io.thp.pyotherside 1.5
 import QtSystemInfo 5.0
-import QtLocation 5.9
+import QtLocation 5.12
 import Lomiri.Components.ListItems 1.3 as ListItem
 import Lomiri.Components.Popups 1.3
 import Morph.Web 0.1

--- a/qml/Tracker.qml
+++ b/qml/Tracker.qml
@@ -1,4 +1,5 @@
-import QtQuick 2.4
+import QtQuick 2.12
+import QtQuick.Layouts 1.12
 import Lomiri.Components 1.3
 import Lomiri.Components.Popups 1.3
 import QtPositioning 5.9
@@ -289,90 +290,112 @@ Rectangle {
          }
       }
 
-      Rectangle {
-         width: parent.width
+       Button {
+          id: floatingPauseButton
+          visible: !is_paused & am_running
+          anchors.bottom: dataRect.top
+          anchors.bottomMargin: units.gu(2)
+          anchors.horizontalCenter: dataRect.horizontalCenter
+          height: units.gu(8)
+          implicitWidth: units.gu(10)
+          text: i18n.tr("Pause")
+          z: parent.z + 1
+          onClicked: pause_recording()
+      }
 
-         height: units.gu(10)
-         // z:100
-         anchors.bottom: parent.bottom
-         color: theme.palette.normal.background
-         opacity: 0.8
-         Row{
-            anchors.horizontalCenter: parent.horizontalCenter
-            spacing: units.gu(2)
-            id: stuffrow
-
+        Rectangle {
+            id: dataRect
+            width: parent.width
+            height: units.gu(13.5)
+            // z:100
+            anchors.bottom: parent.bottom
+            color: theme.palette.normal.background
+            opacity: 0.8
+            property var marginsize: units.gu(2)
+            property var availableWidth: dataRect.width - (5 * marginsize) // full width minus 5 times the spacing of the layout
 
             Column {
-               Label {
-                  text: "Time"
-                  //fontSize: "small"
-               }
-               Label {
-                  text: timestring
-                  fontSize: "large"
-                  //text: "00:00"
-               }
-               Label {
-                  text: "Speed"
-                  fontSize: "small"
-               }
-               Label {
-                  id: speedlabel
-                  text: "No data"
-                  fontSize: "large"
-               }
-            }
-
-            Button {
-               id: startButton
-               text: is_paused ? i18n.tr("Resume") : i18n.tr("Start")
-               color: LomiriColors.green
-               visible: !am_running
-               height: units.gu(10)
-               width: units.gu(15)
-               onClicked: is_paused ? pause_recording() : start_recording()
+                id: leftColumn
+                anchors.left: parent.left
+                anchors.leftMargin: dataRect.marginsize
+                bottomPadding: units.gu(3.5)
+                topPadding: units.gu(1)
+                width: dataRect.availableWidth / 3
+                Label {
+                   text: "Time"
+                   //fontSize: "small"
+                }
+                Label {
+                   text: timestring
+                   fontSize: "large"
+                   //text: "00:00"
+                }
+                Label {
+                   text: "Speed"
+                   fontSize: "small"
+                }
+                Label {
+                   id: speedlabel
+                   text: "No data"
+                   fontSize: "large"
+                }
             }
             Column {
-                height: units.gu(10)
+                id: buttonColumn
+                anchors {
+                    left: leftColumn.right
+                    right: rightColumn.left
+                }
+                bottomPadding: units.gu(3.5)
+                topPadding: units.gu(1)
+                width: dataRect.availableWidth / 3
                 Button {
-                   text: i18n.tr("Pause")
-                   visible:am_running
-                   height: parent.height/2
-                   width: startButton.width
-                   onClicked: pause_recording()
-                }//Button
+                   id: startButton
+                   anchors.horizontalCenter: parent.horizontalCenter
+                   text: is_paused ? i18n.tr("Resume") : i18n.tr("Start")
+                   color: LomiriColors.green
+                   visible: !am_running
+                   height: units.gu(10)
+                   onClicked: is_paused ? pause_recording() : start_recording()
+                }
                 Button {
+                   id: stopButton
+                   anchors.horizontalCenter: parent.horizontalCenter
                    text: i18n.tr("Stop")
                    color: LomiriColors.red
                    visible:am_running
-                   height: parent.height/2
+                   height: startButton.height
                    width: startButton.width
                    onClicked: PopupUtils.open(dialog)
                 }//Button
             }
-            Column {
-               Label {
-                  text: "Distance"
-                  //fontSize: "small"
-               }
-               Label {
-                  id: distlabel
-                  text: "0"
-                  fontSize: "large"
-               }
-               Label {
-                  text: "Altitude"
-                  //  fontSize: "small"
-               }
-               Label {
-                  id: altlabel
-                  text: "No data"
-                  fontSize: "large"
-               }
-            }
 
-         }
-      }//Item (buttons)
-   }
+            Column {
+                id: rightColumn
+                anchors.right: parent.right
+                anchors.rightMargin: dataRect.marginsize
+                bottomPadding: units.gu(3.5)
+                topPadding: units.gu(1)
+                width: dataRect.availableWidth / 3
+                Label {
+                    text: "Distance"
+                    //fontSize: "small"
+                }
+                Label {
+                    id: distlabel
+                    text: "0"
+                    fontSize: "large"
+                }
+                Label {
+                    text: "Altitude"
+                    //  fontSize: "small"
+                }
+                Label {
+                   id: altlabel
+                    text: "No data"
+                    fontSize: "large"
+                }
+            }
+        }
+    }
 }

--- a/qml/Tracker.qml
+++ b/qml/Tracker.qml
@@ -342,10 +342,7 @@ Rectangle {
             }
             Column {
                 id: buttonColumn
-                anchors {
-                    left: leftColumn.right
-                    right: rightColumn.left
-                }
+                anchors.horizontalCenter: parent.horizontalCenter
                 bottomPadding: units.gu(3.5)
                 topPadding: units.gu(1)
                 width: dataRect.availableWidth / 3
@@ -372,8 +369,8 @@ Rectangle {
 
             Column {
                 id: rightColumn
-                anchors.right: parent.right
-                anchors.rightMargin: dataRect.marginsize
+                anchors.left: buttonColumn.right
+                anchors.leftMargin: buttonColumn.marginsize
                 bottomPadding: units.gu(3.5)
                 topPadding: units.gu(1)
                 width: dataRect.availableWidth / 3

--- a/qml/Tracker.qml
+++ b/qml/Tracker.qml
@@ -47,18 +47,12 @@ Rectangle {
       id: newrunPage
       anchors.fill: parent
       header: PageHeader {
-         title: (am_running) ? i18n.tr("Activity in Progress") : is_paused ? i18n.tr("Paused") : i18n.tr("New Activity")
+         title: (am_running) ? i18n.tr("Activity in Progress") : (is_paused) ? i18n.tr("Paused") : i18n.tr("New Activity")
          leadingActionBar.actions: [
          Action {
-            iconName: (am_running) ? "media-playback-pause" : "media-playback-start" //"media-record"
-            onTriggered: {
-               if (am_running) {
-                  pause_recording()
-               }
-               else {
-                  start_recording()
-               }
-            }
+                iconName: "down"
+                enabled: !(am_running) && !(is_paused)
+                onTriggered: newrunEdge.collapse()
          }
          ]
 
@@ -245,18 +239,6 @@ Rectangle {
                }
             }
             PopUpButton {
-               texth: (am_running) ? i18n.tr("Pause recording") : i18n.tr("Resume recording") //Resume recording? Implement where? Here or "stop" button?
-               onClicked: {
-                    if (am_running) {
-                       pause_recording()
-                    }
-                    else {
-                       start_recording()
-                       PopupUtils.close(dialogue)
-                    }
-                }
-            }
-            PopUpButton {
                texth: i18n.tr("Nothing, go back")
                onClicked: PopupUtils.close(dialogue)
             }
@@ -341,22 +323,25 @@ Rectangle {
                color: LomiriColors.green
                visible: !am_running
                height: units.gu(10)
-               //   width:parent.width/2
-               //   height:parent.height
                onClicked: start_recording()
             }
-            Button {
-               text: i18n.tr("Stop")
-               color: LomiriColors.red
-               visible:am_running
-               height: units.gu(10)
-               //   width:parent.width/2
-               //   height:parent.height
-               onClicked: {
-                  PopupUtils.open(dialog)
-
-               }
-            }//Button
+            Column {
+                height: units.gu(10)
+                Button {
+                   text: i18n.tr("Pause")
+                   // color: LomiriColors.red
+                   visible:am_running
+                   height: parent.height/2
+                   onClicked: pause_recording()
+                }//Button
+                Button {
+                   text: i18n.tr("Stop")
+                   color: LomiriColors.red
+                   visible:am_running
+                   height: parent.height/2
+                   onClicked: PopupUtils.open(dialog)
+                }//Button
+            }
             Column {
                Label {
                   text: "Distance"

--- a/qml/Tracker.qml
+++ b/qml/Tracker.qml
@@ -2,8 +2,8 @@ import QtQuick 2.12
 import QtQuick.Layouts 1.12
 import Lomiri.Components 1.3
 import Lomiri.Components.Popups 1.3
-import QtPositioning 5.9
-import QtLocation 5.9
+import QtPositioning 5.12
+import QtLocation 5.12
 import "components"
 
 Rectangle {

--- a/qml/Tracker.qml
+++ b/qml/Tracker.qml
@@ -38,9 +38,15 @@ Rectangle {
    }
 
    function pause_recording() {
-         timer.stop()
-         am_running = false
-         is_paused = true
+       if (is_paused) {
+           timer.start()
+           src.start()
+       } else {
+           timer.stop()
+           src.stop()
+       }
+       am_running = !am_running
+       is_paused = !is_paused
    }
 
    Page {
@@ -90,7 +96,7 @@ Rectangle {
             map.center = QtPositioning.coordinate(coord.latitude, coord.longitude)
             circle.center = QtPositioning.coordinate(coord.latitude, coord.longitude)
 
-            if (gpxx && am_running){
+            if (gpxx && am_running && !is_paused){
 
                if (src.position.latitudeValid && src.position.longitudeValid && src.position.altitudeValid) {
                   //pygpx.addpoint(gpxx,coord.latitude,coord.longitude,coord.altitude)
@@ -261,7 +267,7 @@ Rectangle {
                pygpx.format_timer(0)
                timer.restart()
                timer.stop()
-
+               map.removeMapItem(pline)
                //  listModel.append({"name": tf.displayText, "act_type": sportsComp.name[sportsComp.selected]})
                //   pygpx.addrun(tf.displayText)
                listModel.clear()

--- a/qml/Tracker.qml
+++ b/qml/Tracker.qml
@@ -325,11 +325,13 @@ Rectangle {
             }
 
             Button {
+               id: startButton
                text: is_paused ? i18n.tr("Resume") : i18n.tr("Start")
                color: LomiriColors.green
                visible: !am_running
                height: units.gu(10)
-               onClicked: start_recording()
+               width: units.gu(15)
+               onClicked: is_paused ? pause_recording() : start_recording()
             }
             Column {
                 height: units.gu(10)
@@ -337,6 +339,7 @@ Rectangle {
                    text: i18n.tr("Pause")
                    visible:am_running
                    height: parent.height/2
+                   width: startButton.width
                    onClicked: pause_recording()
                 }//Button
                 Button {
@@ -344,6 +347,7 @@ Rectangle {
                    color: LomiriColors.red
                    visible:am_running
                    height: parent.height/2
+                   width: startButton.width
                    onClicked: PopupUtils.open(dialog)
                 }//Button
             }

--- a/qml/Tracker.qml
+++ b/qml/Tracker.qml
@@ -329,7 +329,6 @@ Rectangle {
                 height: units.gu(10)
                 Button {
                    text: i18n.tr("Pause")
-                   // color: LomiriColors.red
                    visible:am_running
                    height: parent.height/2
                    onClicked: pause_recording()


### PR DESCRIPTION
Only merge after #44  !

This PR **based on focal branch** does address two issues:
1. it will add an option to pause recording (#46 )
2. it will improve cancel/discard track handling (#45 )

I will mark it as draft for now so we can discuss the UI and wait for the focal PR to get merged.

We can not (easily) fully omit bottom edge's "down arrow". So my idea was that the down arrow will become a "start/pause" button. (screenshot 1, 2, 3) Using it for pause/resume actually feels quite convenient in real use. 

The "start" header button does the same as pressing the square green "start" button (yes, redundant).
The "pause" button will pause the recording and change to "start" to allow resume.

The dialog popping up when pressing the red square "stop" button I changed to hold 4 buttons:
a) stop and save recording (as before)
b) stop and discard recording (moved here from header down arrow)
c) pause (new)
d) do nothing, go back (as before)
There are two colored buttons in that menu. That somehow seems to make sense. Although I am aware that this violates the OS UI guidelines. But many current dialogs do that too actually.
Also we could remove pause from this menu and only have it in the header. But I think handling with the larger buttons is better when you are doing some sports rather than aiming for the small header icon. I would keep both options.

Screenshots 1, 2, 3 start/resume/pause:

![grafik](https://user-images.githubusercontent.com/37637312/236492884-8d1db0e6-705c-4112-b11b-8a2e32ac222d.png)

![grafik](https://user-images.githubusercontent.com/37637312/236493244-a7b9a27e-69d2-4871-a684-527da19f0c54.png)

![grafik](https://user-images.githubusercontent.com/37637312/236492943-f0e96d44-b5c5-4354-90df-25c61a3e8bd9.png)

Screenshots 4, 5, 6 new menu layout (menu with pause, menu with resume, cancel and discard dialog):

![grafik](https://user-images.githubusercontent.com/37637312/236493404-ea17e13a-8c19-4f8e-95c9-053312a34b95.png)

![grafik](https://user-images.githubusercontent.com/37637312/236493374-af1a95d8-41a4-40c3-b5ce-44432745788f.png)

![grafik](https://user-images.githubusercontent.com/37637312/236493447-13732235-73c5-456f-a165-41904435c87f.png)
